### PR TITLE
feat: add layout component

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>{{ $title ?? config('app.name') }}</title>
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=figtree:400,600&display=swap" rel="stylesheet" />
+
+    <!-- Scripts & Styles -->
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="antialiased">
+    {{ $slot }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new component layout app.blade.php to allow `<x-layouts.app>` usage

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: General error: 1 error in index exams_code_unique after drop column: no such column: code)*

------
https://chatgpt.com/codex/tasks/task_b_68a547d60bfc832aafabfb1e6838a7b1